### PR TITLE
Update GLTFExporter.js

### DIFF
--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -2113,7 +2113,7 @@ class GLTFWriter {
 			if ( ! trackNode || ! trackProperty ) {
 
 				console.warn( 'THREE.GLTFExporter: Could not export animation track "%s".', track.name );
-				return null;
+				continue;
 
 			}
 


### PR DESCRIPTION
Remove unnecessary early return

Related issue: No related issues

**Description**

When deleting nodes within the imported GLB/GLTF model, if the deleted node is referenced by some animation, exporting the GLB again will cause the entire animation track to be discarded, instead of only discarding the animation related to the deleted node. This issue is caused by unnecessary early returns in the GLTFExporter. Changing the `return` statements to `continue` resolves this problem.
